### PR TITLE
build(workflows): run actions more frequent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches: 
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
The latest change seemed to prevent a check run whenever we merged a pull request. Due to this, the action was not clickable from the latest commit on master. I prefer to run too many pipelines, rather than not enough.